### PR TITLE
Don't perform html escaping in mustache

### DIFF
--- a/websocket-api-impl/src/main/java/de/uni_stuttgart/tik/viplab/websocket_api/transformation/ComputationMergerImpl.java
+++ b/websocket-api-impl/src/main/java/de/uni_stuttgart/tik/viplab/websocket_api/transformation/ComputationMergerImpl.java
@@ -29,6 +29,7 @@ import de.uni_stuttgart.tik.viplab.websocket_api.model.FixedValueParameter.Optio
 import de.uni_stuttgart.tik.viplab.websocket_api.model.Parameter;
 import de.uni_stuttgart.tik.viplab.websocket_api.validation.ConfigurationValidatorManager;
 import de.uni_stuttgart.tik.viplab.websocket_api.validation.ParameterValidator;
+import io.quarkus.logging.Log;
 
 @ApplicationScoped
 public class ComputationMergerImpl implements ComputationMerger {
@@ -203,13 +204,20 @@ public class ComputationMergerImpl implements ComputationMerger {
               parameter)) {
         throw new IllegalArgumentException("Argument not valid: " + parameter.getIdentifier());
       }
+      if (value.startsWith("base64:")) {
+    	  value = value.replaceFirst("^base64:", "");
+    	  value = new String(Base64.getUrlDecoder()
+    	            .decode(value), StandardCharsets.UTF_8);
+    	  Log.debug("----------" + value + "----------");
+      }
       parameters.put(parameter.getIdentifier(),
               value);
     });
 
     String renderedTemplate = templateRenderer.renderTemplate(template,
             parameters);
-
+    Log.debug(renderedTemplate);
+    Log.debug("----------" + Base64.getUrlEncoder().encodeToString(renderedTemplate.getBytes(StandardCharsets.UTF_8)) + "----------");
     return Base64.getUrlEncoder()
             .encodeToString(renderedTemplate.getBytes(StandardCharsets.UTF_8));
   }

--- a/websocket-api-impl/src/main/java/de/uni_stuttgart/tik/viplab/websocket_api/transformation/TemplateRendererImpl.java
+++ b/websocket-api-impl/src/main/java/de/uni_stuttgart/tik/viplab/websocket_api/transformation/TemplateRendererImpl.java
@@ -1,14 +1,19 @@
 package de.uni_stuttgart.tik.viplab.websocket_api.transformation;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
+
+import io.quarkus.logging.Log;
 
 /**
  * This TemplateRenderer uses the mustache library to replace parameter in the
@@ -20,14 +25,33 @@ import com.github.mustachejava.MustacheFactory;
 @ApplicationScoped
 public class TemplateRendererImpl implements TemplateRenderer {
 
-	private final MustacheFactory mf = new DefaultMustacheFactory();
-
+	private final MustacheFactory mf = new CustomMustacheFactory();
+	
 	@Override
 	public String renderTemplate(String template, Map<String, String> parameters) {
 		Mustache mustache = mf.compile(new StringReader(template), "example");
 		StringWriter writer = new StringWriter();
+		Log.debug("---------- Mustache Input: " + parameters + "----------");
 		mustache.execute(writer, parameters);
 		return writer.toString();
 	}
+	
+	
 
+}
+
+class CustomMustacheFactory extends DefaultMustacheFactory {
+
+	@Override
+	/**
+	 * Override encode to disable html encoding
+	 */
+	public void encode(String value, Writer writer) {
+		try {
+	        writer.append(value);
+	    } catch (IOException e) {
+	        throw new MustacheException("Failed to append value: " + value);
+	    }
+	}
+	
 }

--- a/websocket-api-impl/src/main/resources/application.properties
+++ b/websocket-api-impl/src/main/resources/application.properties
@@ -2,3 +2,4 @@ viplab.jwt.jwks.file=${JWKS_FILE}
 %test.viplab.jwt.jwks.file=src/test/resources/test-jwks.json
 %test.viplab.jwt.jwks.file.private.test=src/test/resources/test-jwks.private.json
 %test.viplab.jwt.jwks.kid.test=testkeyId
+quarkus.log.level=info


### PR DESCRIPTION
Adittionally decode editorfields and input_fields and after that, stop mustache from automatically do html escaping, by overriding the escape-method of the DefaultMustacheFactory